### PR TITLE
frame_skip arg name is wrong: num_frames -> frame_skip

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You can install SuperSuit via `pip install supersuit`
 
 `flatten_v0(env)` flattens observations into a 1D array.
 
-`frame_skip_v0(env, num_frames, seed=None)` skips `num_frames` number of frames by reapplying old actions over and over. Observations skipped over are ignored. Rewards skipped over are accumulated. Like Gym Atari's frameskip parameter, `num_frames` can also be a tuple `(min_skip, max_skip)`, which indicates a range of possible skip lengths which are randomly chosen from (in single agent environments only).
+`frame_skip_v0(env, frame_skip, seed=None)` skips `frame_skip` number of frames by reapplying old actions over and over. Observations skipped over are ignored. Rewards skipped over are accumulated. Like Gym Atari's frameskip parameter, `frame_skip` can also be a tuple `(min_skip, max_skip)`, which indicates a range of possible skip lengths which are randomly chosen from (in single agent environments only).
 
 `delay_observations_v0(env, delay, seed=None)` Delays observation by `delay` frames. Before `delay` frames have been executed, the observation is all zeros. Along with frame_skip, this is the preferred way to implement reaction time for high FPS games.
 


### PR DESCRIPTION
https://github.com/PettingZoo-Team/SuperSuit/blob/master/supersuit/aec_wrappers.py#L238

I just saw the separate frame_skip_stack branch partially addressing this. Until that is merged, it would be good to have the doc be consistent with the correct arg name.

For my use: will this combination of skip and stack be pushed out anytime soon, and will it offer benefits other than convenience over just using the skip wrapper and stack wrapper sequentially? 