### PR TITLE
fixed parallel frame skip wrapper

### DIFF
--- a/supersuit/parallel_wrappers.py
+++ b/supersuit/parallel_wrappers.py
@@ -95,14 +95,16 @@ class frame_skip(ParallelWraper):
     def step(self, action):
         low, high = self.num_frames
         num_skips = int(self.np_random.randint(low, high + 1))
-        next_agents = self.env.agents[:]
-        total_reward = {agent: 0.0 for agent in self.env.agents}
-        total_dones = {}
-        total_infos = {}
-        total_obs = {}
 
         for x in range(num_skips):
             obs, rews, done, info = super().step(action)
+            if x == 0:
+                next_agents = self.env.agents[:]
+                total_reward = {agent: 0.0 for agent in self.env.agents}
+                total_dones = {}
+                total_infos = {}
+                total_obs = {}
+
             for agent, rew in rews.items():
                 total_reward[agent] += rew
                 total_dones[agent] = done[agent]

--- a/supersuit/parallel_wrappers.py
+++ b/supersuit/parallel_wrappers.py
@@ -95,13 +95,20 @@ class frame_skip(ParallelWraper):
     def step(self, action):
         low, high = self.num_frames
         num_skips = int(self.np_random.randint(low, high + 1))
-        total_reward = {agent: 0.0 for agent in self.agents}
+        next_agents = self.env.agents[:]
+        total_reward = {agent: 0.0 for agent in self.env.agents}
+        total_dones = {}
+        total_infos = {}
+        total_obs = {}
 
         for x in range(num_skips):
             obs, rews, done, info = super().step(action)
             for agent, rew in rews.items():
                 total_reward[agent] += rew
+                total_dones[agent] = done[agent]
+                total_infos[agent] = info[agent]
+                total_obs[agent] = obs[agent]
             if all(done.values()):
                 break
-
-        return obs, total_reward, done, info
+        self.agents = next_agents
+        return total_obs, total_reward, total_dones, total_infos


### PR DESCRIPTION
Yeah, turns out the parallel frame skip wrapper also broke during the API changes, but I didn't notice.

The ideal solution here is to remove this wrapper, and bootstrap the aec frame skip wrapper (like most of the wrappers in supersuit), but I'll have to check that this works as expected and doesn't have performance issues.